### PR TITLE
Fix storybook build-and-deploy #70

### DIFF
--- a/.github/workflows/storybook.yml
+++ b/.github/workflows/storybook.yml
@@ -12,8 +12,11 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Install and Build
+        with:
+          node-version: 14.x      
         run: |
           npm install
+          export NODE_OPTIONS=--openssl-legacy-provider
           npm run build-storybook
 
       - name: Deploy


### PR DESCRIPTION
trying to fix this error:
https://github.com/vczb/sagu-ui/actions/runs/4840676257/jobs/8626474481

```
node:internal/crypto/hash:71
  this[kHandle] = new _Hash(algorithm, xofLen);
                  ^

Error: error:0308010C:digital envelope routines::unsupported
    at new Hash (node:internal/crypto/hash:71:19)
    at Object.createHash (node:crypto:133:10)
    at module.exports (/home/runner/work/sagu-ui/sagu-ui/node_modules/webpack/lib/util/createHash.js:135:53)
    at NormalModule._initBuildHash (/home/runner/work/sagu-ui/sagu-ui/node_modules/webpack/lib/NormalModule.js:417:16)
    at handleParseError (/home/runner/work/sagu-ui/sagu-ui/node_modules/webpack/lib/NormalModule.js:4[71](https://github.com/vczb/sagu-ui/actions/runs/4840676257/jobs/8626474481#step:3:72):10)
    at /home/runner/work/sagu-ui/sagu-ui/node_modules/webpack/lib/NormalModule.js:503:5
    at /home/runner/work/sagu-ui/sagu-ui/node_modules/webpack/lib/NormalModule.js:358:12
    at /home/runner/work/sagu-ui/sagu-ui/node_modules/loader-runner/lib/LoaderRunner.js:3[73](https://github.com/vczb/sagu-ui/actions/runs/4840676257/jobs/8626474481#step:3:74):3
    at iterateNormalLoaders (/home/runner/work/sagu-ui/sagu-ui/node_modules/loader-runner/lib/LoaderRunner.js:214:10)
    at /home/runner/work/sagu-ui/sagu-ui/node_modules/loader-runner/lib/LoaderRunner.js:205:4
    at /home/runner/work/sagu-ui/sagu-ui/node_modules/enhanced-resolve/lib/CachedInputFileSystem.js:85:15
    at process.processTicksAndRejections (node:internal/process/task_queues:[77](https://github.com/vczb/sagu-ui/actions/runs/4840676257/jobs/8626474481#step:3:78):11) {
  opensslErrorStack: [ 'error:03000086:digital envelope routines::initialization error' ],
  library: 'digital envelope routines',
  reason: 'unsupported',
  code: 'ERR_OSSL_EVP_UNSUPPORTED'
}

Node.js v18.16.0
Error: Process completed with exit code 1.
```