### PR TITLE
Remove node-version from storybook build-deploy

### DIFF
--- a/.github/workflows/storybook.yml
+++ b/.github/workflows/storybook.yml
@@ -12,8 +12,6 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Install and Build
-        with:
-          node-version: 14.x      
         run: |
           npm install
           export NODE_OPTIONS=--openssl-legacy-provider


### PR DESCRIPTION
Fix
https://github.com/vczb/sagu-ui/actions/runs/4840740049
```
[Invalid workflow file: .github/workflows/storybook.yml#L17](https://github.com/vczb/sagu-ui/actions/runs/4840740049/workflow)
The workflow is not valid. .github/workflows/storybook.yml (Line: 17, Col: 9): Unexpected value 'run' .github/workflows/storybook.yml (Line: 14, Col: 9): Required property is missing: uses
```