### PR TITLE
test: fix skipped tests

### DIFF
--- a/src/packages/Breadcrumb/index.tsx
+++ b/src/packages/Breadcrumb/index.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { Fragment } from 'react'
 import NavLink, { NavLinkProps } from '../NavLink'
 import { SpacingKeys } from '../../styles/spacingModifier'
 import * as S from './styles'
@@ -26,7 +26,7 @@ const Breadcrumb = ({
   return (
     <S.Breadcrumb>
       {items.map((item, index) => (
-        <>
+        <Fragment key={index}>
           {index > 0 && (
             <S.BreadcrumbItem
               key={`breadcrumb-${separator}-${index}`}
@@ -50,7 +50,7 @@ const Breadcrumb = ({
               {item.name}
             </NavLink>
           </S.BreadcrumbItem>
-        </>
+        </Fragment>
       ))}
     </S.Breadcrumb>
   )

--- a/src/packages/Breadcrumb/test.tsx
+++ b/src/packages/Breadcrumb/test.tsx
@@ -16,8 +16,7 @@ const mock = [
     link: '/blog/tech/react'
   }
 ]
-// TODO: Fix this test
-describe.skip('<Breadcrumb>', () => {
+describe('<Breadcrumb>', () => {
   it('Should render the breadcrumb', () => {
     const { container } = render(<Breadcrumb items={mock} />)
     expect(container).toBeInTheDocument()

--- a/src/packages/Paper/index.tsx
+++ b/src/packages/Paper/index.tsx
@@ -17,7 +17,12 @@ const Paper = ({
   ...props
 }: PaperProps) => {
   return (
-    <S.Paper aria-hidden={!active} active={active} placement={placement}>
+    <S.Paper
+      aria-hidden={!active}
+      active={active}
+      placement={placement}
+      data-testid="paper"
+    >
       <Box {...props} shadow border padding={padding}>
         {children}
       </Box>

--- a/src/packages/Paper/test.tsx
+++ b/src/packages/Paper/test.tsx
@@ -4,11 +4,10 @@ import { theme } from '../../styles'
 
 import Paper from '.'
 
-// TODO: fix tests
-describe.skip('<Paper />', () => {
+describe('<Paper />', () => {
   it('Should render when active is true', () => {
     render(
-      <Paper active={true} placement="right" data-testid="paper">
+      <Paper active={true} placement="right">
         <p>Hello world!</p>
       </Paper>
     )
@@ -17,7 +16,7 @@ describe.skip('<Paper />', () => {
   })
   it('Should not render when active is false', () => {
     render(
-      <Paper active={false} placement="right" data-testid="paper">
+      <Paper active={false} placement="right">
         <p>Hello world!</p>
       </Paper>
     )
@@ -35,7 +34,7 @@ describe.skip('<Paper />', () => {
   })
   it('Should render in bottom placement', () => {
     render(
-      <Paper placement="bottom" data-testid="paper">
+      <Paper placement="bottom">
         <></>
       </Paper>
     )
@@ -47,7 +46,7 @@ describe.skip('<Paper />', () => {
   })
   it('Should render in left placement', () => {
     render(
-      <Paper placement="left" data-testid="paper">
+      <Paper placement="left">
         <></>
       </Paper>
     )
@@ -59,7 +58,7 @@ describe.skip('<Paper />', () => {
   })
   it('Should render in right placement', () => {
     render(
-      <Paper placement="right" data-testid="paper">
+      <Paper placement="right">
         <></>
       </Paper>
     )


### PR DESCRIPTION
PR refers to issue: #95 
This PR removes .skip of broken tests from the components below:
- Breadcrumb
The first component inside map should receive a `key`prop to be render.
<img src="https://github.com/vczb/sagu-ui/assets/45365825/f8138b65-62ca-4449-9a83-e88889959850" width="60%"/>

- Paper
data-testid was used wrong, he should be pass inside the creation of component, because is there that display is controlled, not in the tests.
<img src="https://github.com/vczb/sagu-ui/assets/45365825/e939c71c-4daa-493e-9a3d-e15f72d2ae8d" width="60%"/>