### PR TITLE
fixed the License icon on the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,6 +198,6 @@ Thanks for all who is contributing with us.
 
 Be part of this amazing team, [contribute](./CONTRIBUTING.md) as well
 
-## License 🪪
+## License 📜
 
 This project is licensed under the [MIT](./LICENSE) License.


### PR DESCRIPTION
This PR modifies the License icon on the README from 🪪 to 📜

Fixes #110

![Screenshot 2023-10-17 150214](https://github.com/vczb/sagu-ui/assets/140940344/a6ac1ea8-d04d-473a-ba0f-8882a10ed8ca)

##Type of change
-This change requires a documentation update

##How should this be tested?
-[ ] go to bottom of the README.md file
-[ ] check the License icon rendering there

