### PR TITLE
test: add test for heading and tag component

### DIFF
--- a/src/packages/Heading/test.tsx
+++ b/src/packages/Heading/test.tsx
@@ -1,0 +1,16 @@
+import React from 'react'
+import { render, screen } from '../../utils/testUtils'
+
+import Heading from '.'
+
+describe('<Heading/>', () => {
+  it('should render the heading', () => {
+    render(
+      <Heading>
+        <span>This is the heading</span>
+      </Heading>
+    )
+
+    expect(screen.getByText('This is the heading')).toBeInTheDocument()
+  })
+})

--- a/src/packages/Tag/test.tsx
+++ b/src/packages/Tag/test.tsx
@@ -1,0 +1,18 @@
+import React from 'react'
+import { render, screen } from '../../utils/testUtils'
+
+import Tag from '.'
+
+describe('<Tag/>', () => {
+  it('should render the tag value given', () => {
+    render(<Tag value="coffee" />)
+
+    expect(screen.getByText('coffee')).toBeInTheDocument()
+  })
+
+  it('should render tag with uppercase content', async () => {
+    const dom = render(<Tag value="coffee" isUppercase={true} />)
+
+    expect(dom.getByText(/COFFEE/i)).toBeInTheDocument()
+  })
+})


### PR DESCRIPTION
This PR is for https://github.com/vczb/sagu-ui/issues/7

Components tested - Heading, Tag

Screenshots of passing test
<img width="453" alt="image" src="https://github.com/vczb/sagu-ui/assets/81218987/668de671-596b-4dbf-97ba-36fa8dc8214d">
<img width="565" alt="image" src="https://github.com/vczb/sagu-ui/assets/81218987/2241d82a-6f3b-48ac-9955-229dd4977b55">
