### PR TITLE
Fix rating component: Star width set to medium

### DIFF
--- a/src/packages/Rating/style.ts
+++ b/src/packages/Rating/style.ts
@@ -10,7 +10,7 @@ export const RatingContainer = styled.div`
 
     :not(:checked) > label {
       float: right;
-      width: ${theme.font.sizes.xsmall};
+      width: ${theme.font.sizes.medium};
       overflow: hidden;
       white-space: nowrap;
       cursor: pointer;


### PR DESCRIPTION
<img width="1073" alt="Screenshot 2023-11-02 at 11 33 50 PM" src="https://github.com/vczb/sagu-ui/assets/104359410/278f6583-069f-41e0-95db-d3c724d73fdb">

I noticed that the star radio element in the rating component was being cut off because its width was set to xsmall (1.2rem). I tried increasing the width to small, but it was still being cut off slightly. Setting the width to 1.5rem seemed to fix the problem, but this value is not available in our theme. Therefore, I have set the width to medium (1.6rem) instead. This fixes the issue and the star radio element now looks as expected (see screenshot).

<img width="1107" alt="Screenshot 2023-11-02 at 11 35 56 PM" src="https://github.com/vczb/sagu-ui/assets/104359410/bc265d35-eb23-4f18-90e2-3d6de344c43f">

Please review and merge. Thanks.